### PR TITLE
Remove run datamanager role to speed up build process

### DIFF
--- a/group_vars/metavisitor
+++ b/group_vars/metavisitor
@@ -2,6 +2,7 @@ galaxy_tools_tool_list_files:
   - "extra-files/metavisitor/metavisitor_tool_list.yml"
 
 galaxy_restart_handler_enabled: no
+gks_run_data_managers: no
 galaxy_tools_install_data_managers: no
 galaxy_tools_data_managers_list: "extra-files/metavisitor/metavisitor_run_data_managers.yaml"
 

--- a/group_vars/test
+++ b/group_vars/test
@@ -8,6 +8,7 @@ postgres_user_gid: 1550
 install_apparmor: false
 
 galaxy_restart_handler_enabled: no
+gks_run_data_managers: no
 galaxy_tools_install_data_managers: no
 galaxy_tools_data_managers_list: "extra-files/metavisitor/metavisitor_run_data_managers.yaml"
 


### PR DESCRIPTION
added gks_run_data_managers: no in group_vars/... to avoid data_managers runs

Anyway, this has to be done on a user-by-user basis