### PR TITLE
minor change to mkdocs.yml after merge to master to trigger mkdocs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Metavisitor
+site_name: Metavisitor-2
 pages:
   - Metavisitor: index.md
   - Prepare Metavisitor Galaxy instance for analyses: metavisitor_configure_references.md

--- a/travis_before_install.sh
+++ b/travis_before_install.sh
@@ -77,7 +77,7 @@ fi
 
 if [ "$TRACK" = "build-docker" ] && [ "${TRAVIS_EVENT_TYPE}" = "pull_request" ]; then
     docker build -t metavisitor .
-    docker tag metavisitor artbio/metavisitor-2-beta:$TRAVIS_COMMIT
-    docker tag metavisitor artbio/metavisitor-2-beta:latest
+    docker tag metavisitor artbio/metavisitor-2:$TRAVIS_COMMIT
+    docker tag metavisitor artbio/metavisitor-2:latest
 fi
 

--- a/travis_push_docker.sh
+++ b/travis_push_docker.sh
@@ -5,7 +5,7 @@ if [ $TRAVIS_JOB = "build-docker" ] && [ "${TRAVIS_EVENT_TYPE}" = "pull_request"
     echo "pushing docker image to docker hub"
     LOGIN="docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD"
     $LOGIN || (sleep 5s && $LOGIN || echo "login failed twice, quitting" && exit 1)
-    docker push artbio/metavisitor-2-beta:$TRAVIS_COMMIT || (sleep 5s && docker push artbio/metavisitor-2-beta:$TRAVIS_COMMIT || echo "push failed twice, quitting" && exit 1)
-    docker push artbio/metavisitor-2-beta:latest || (sleep 5s && docker push artbio/metavisitor-2-beta:latest || echo "push failed twice, quitting" && exit 1)
+    docker push artbio/metavisitor-2:$TRAVIS_COMMIT || (sleep 5s && docker push artbio/metavisitor-2:$TRAVIS_COMMIT || echo "push failed twice, quitting" && exit 1)
+    docker push artbio/metavisitor-2:latest || (sleep 5s && docker push artbio/metavisitor-2:latest || echo "push failed twice, quitting" && exit 1)
 fi
 


### PR DESCRIPTION
Basically, the GalaxyKickStart Flavor repository is structured as follows:

- At root, the specific files for the flavors, including `group_vars` metavisitor and test, `inventory_files`, extra_files for metavisitor and test, and 2 docker files for metavisitor build and metavisitor test container.
- In addition, a tar.gz archive of galaxykickstart tag `release_17.09` *including the extra roles* is ready for decompression. This setting isolate completely metavisitor-2 for changes in galaxykickstart as well as extra-roles (which is expected with the migration to 18.01).
- there are a number of scripts. Some are for deployment in a standalone situation (and may be still improved). Others are utilized for travis testing.
- Finally the mkdocs doc has been imported from the repo metavisitor-manual and the deployment is automated following pull request.

- The testing / deployment in docker hub "artbio/metavisitor-2" involves 3 travis jobs that often fails when run together. but retrying one by one generally works well.

The repo is now ready for the last phase before publication: linting all tools and workflows, include information to download vir-2 (which should have a doi), and maybe the most heavy work, update the documentation to make it as useful and easy as possible