### PR TITLE
Improvetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,19 +31,19 @@ jobs:
         - . $TRAVIS_BUILD_DIR/deploy_doc.sh
 
     - stage: test
-      if: (type = push) AND (branch != master)
+      if: (type = push) AND (branch != master) AND !(branch =~ doc)
       env:
         - TRAVIS_JOB=docker
         - BIOBLEND_GALAXY_URL="http://localhost:80/subdir/"
 
     - stage: test
-      if: (type = push) AND (branch != master)
+      if: (type = push) AND (branch != master) AND !(branch =~ doc)
       env:
         - TRAVIS_JOB=ansible
         - BIOBLEND_GALAXY_URL="http://localhost:80"
 
     - stage: deploy
-      if: (type = push) AND (branch = master)
+      if: (type = push) AND (branch = master) AND !(branch =~ doc)
       before_install: skip
       install: skip
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
   include:
 
     - stage: documentation
+      if: (branch =~ doc)
       before_install: skip
       install: skip
       script:


### PR DESCRIPTION
@ccedmendoza @NairaNaouar 
Now, changed in documentation should be pushed from branches whose name contains the string `doc`. For instance, branch `mydocchanges` or `chris_doc_patch`

This will avoid building a new docker image each time we change the doc !
